### PR TITLE
Added new Pawn Job for filling Barrels with Must

### DIFF
--- a/About/About-Debug.xml
+++ b/About/About-Debug.xml
@@ -2,7 +2,7 @@
 <ModMetaData>
 	<name>KT28's Winemaking - Dev Build</name>
 	<author>KT28</author>
-	<targetVersion>0.19.2017</targetVersion>
+	<targetVersion>1.0.2026</targetVersion>
 	<description>Adds winemaking to Rimworld
 (This is the dev version of rw-wine-mod. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/KT28/myworkshopfiles/?appid=294100</url>

--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,7 @@
 	<name>KT28's Winemaking - Dev Build</name>
 	<author>KT28</author>
 	<targetVersion>0.19.2017</targetVersion>
-	<description>Adds winemaking to Rimworld 
+	<description>Adds winemaking to Rimworld
 (This is the dev version of rw-wine-mod. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/KT28/myworkshopfiles/?appid=294100</url>
 </ModMetaData>

--- a/About/About.xml
+++ b/About/About.xml
@@ -2,7 +2,7 @@
 <ModMetaData>
 	<name>KT28's Winemaking - Dev Build</name>
 	<author>KT28</author>
-	<targetVersion>0.19.2017</targetVersion>
+	<targetVersion>1.0.2026</targetVersion>
 	<description>Adds winemaking to Rimworld
 (This is the dev version of rw-wine-mod. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/KT28/myworkshopfiles/?appid=294100</url>

--- a/Defs/JobsDefs/Jobs_Misc.xml
+++ b/Defs/JobsDefs/Jobs_Misc.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Defs>
+  <JobDef>
+    <defName>FillMustFermentingBarrel</defName>
+    <driverClass>RwWineMod.JobDriver_FillMustFermentingBarrel</driverClass>
+    <reportString>filling TargetA.</reportString>
+    <suspendable>false</suspendable>
+    <allowOpportunisticPrefix>true</allowOpportunisticPrefix>
+  </JobDef>
+</Defs>

--- a/Defs/RuleDefs/BrewingRules.xml
+++ b/Defs/RuleDefs/BrewingRules.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Defs>
+  <RuleDef>
+    <defName>AddMustToFermentingBarrels</defName>
+    <symbol>addMustToFermentingBarrels</symbol>
+    <resolvers>
+      <li Class="RwWineMod.SymbolResolver_AddMustToFermentingBarrels" />
+    </resolvers>
+  </RuleDef>
+</Defs>

--- a/Defs/WorkGiverDefs/WorkGivers.xml
+++ b/Defs/WorkGiverDefs/WorkGivers.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Defs>
+  <WorkGiverDef>
+    <defName>FillMustFermentingBarrel</defName>
+    <label>fill fermenting barrels with must</label>
+    <giverClass>RwWineMod.WorkGiver_FillMustFermentingBarrel</giverClass>
+    <workType>Hauling</workType>
+    <verb>fill</verb>
+    <gerund>filling</gerund>
+    <priorityInType>18</priorityInType>
+    <requiredCapacities>
+      <li>Manipulation</li>
+    </requiredCapacities>
+  </WorkGiverDef>
+</Defs>

--- a/Source/JobDriver_FillMustFermentingBarrel.cs
+++ b/Source/JobDriver_FillMustFermentingBarrel.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using Verse;
+using Verse.AI;
+using RimWorld;
+
+namespace RwWineMod
+{
+  // Token: 0x02000068 RID: 104
+  public class JobDriver_FillMustFermentingBarrel : JobDriver
+  {
+    // Token: 0x17000097 RID: 151
+    // (get) Token: 0x060002E7 RID: 743 RVA: 0x0001C770 File Offset: 0x0001AB70
+    protected Building_FermentingBarrel Barrel
+    {
+      get
+      {
+        return (Building_FermentingBarrel)this.job.GetTarget(TargetIndex.A).Thing;
+      }
+    }
+
+    // Token: 0x17000098 RID: 152
+    // (get) Token: 0x060002E8 RID: 744 RVA: 0x0001C798 File Offset: 0x0001AB98
+    protected Thing Must
+    {
+      get
+      {
+        return this.job.GetTarget(TargetIndex.B).Thing;
+      }
+    }
+
+    // Token: 0x060002E9 RID: 745 RVA: 0x0001C7BC File Offset: 0x0001ABBC
+    public override bool TryMakePreToilReservations(bool errorOnFailed)
+    {
+      Pawn pawn = this.pawn;
+      LocalTargetInfo target = this.Barrel;
+      Job job = this.job;
+      bool result;
+      if (pawn.Reserve(target, job, 1, -1, null, errorOnFailed))
+      {
+        pawn = this.pawn;
+        target = this.Must;
+        job = this.job;
+        result = pawn.Reserve(target, job, 1, -1, null, errorOnFailed);
+      }
+      else
+      {
+        result = false;
+      }
+      return result;
+    }
+
+    // Token: 0x060002EA RID: 746 RVA: 0x0001C824 File Offset: 0x0001AC24
+    protected override IEnumerable<Toil> MakeNewToils()
+    {
+      this.FailOnDespawnedNullOrForbidden(TargetIndex.A);
+      this.FailOnBurningImmobile(TargetIndex.A);
+      base.AddEndCondition(() => (this.Barrel.SpaceLeftForWort > 0) ? JobCondition.Ongoing : JobCondition.Succeeded);
+      yield return Toils_General.DoAtomic(delegate
+      {
+        this.job.count = this.Barrel.SpaceLeftForWort;
+      });
+      Toil reserveMust = Toils_Reserve.Reserve(TargetIndex.B, 1, -1, null);
+      yield return reserveMust;
+      yield return Toils_Goto.GotoThing(TargetIndex.B, PathEndMode.ClosestTouch).FailOnDespawnedNullOrForbidden(TargetIndex.B).FailOnSomeonePhysicallyInteracting(TargetIndex.B);
+      yield return Toils_Haul.StartCarryThing(TargetIndex.B, false, true, false).FailOnDestroyedNullOrForbidden(TargetIndex.B);
+      yield return Toils_Haul.CheckForGetOpportunityDuplicate(reserveMust, TargetIndex.B, TargetIndex.None, true, null);
+      yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.Touch);
+      yield return Toils_General.Wait(200, TargetIndex.None).FailOnDestroyedNullOrForbidden(TargetIndex.B).FailOnDestroyedNullOrForbidden(TargetIndex.A).FailOnCannotTouch(TargetIndex.A, PathEndMode.Touch).WithProgressBarToilDelay(TargetIndex.A, false, -0.5f);
+      yield return new Toil
+      {
+        initAction = delegate ()
+        {
+          this.Barrel.AddWort(this.Must);
+        },
+        defaultCompleteMode = ToilCompleteMode.Instant
+      };
+      yield break;
+    }
+
+    // Token: 0x0400020C RID: 524
+    private const TargetIndex BarrelInd = TargetIndex.A;
+
+    // Token: 0x0400020D RID: 525
+    private const TargetIndex MustInd = TargetIndex.B;
+
+    // Token: 0x0400020E RID: 526
+    private const int Duration = 200;
+  }
+}

--- a/Source/JobDriver_FillMustFermentingBarrel.cs
+++ b/Source/JobDriver_FillMustFermentingBarrel.cs
@@ -6,11 +6,8 @@ using RimWorld;
 
 namespace RwWineMod
 {
-  // Token: 0x02000068 RID: 104
   public class JobDriver_FillMustFermentingBarrel : JobDriver
   {
-    // Token: 0x17000097 RID: 151
-    // (get) Token: 0x060002E7 RID: 743 RVA: 0x0001C770 File Offset: 0x0001AB70
     protected Building_FermentingBarrel Barrel
     {
       get
@@ -18,9 +15,7 @@ namespace RwWineMod
         return (Building_FermentingBarrel)this.job.GetTarget(TargetIndex.A).Thing;
       }
     }
-
-    // Token: 0x17000098 RID: 152
-    // (get) Token: 0x060002E8 RID: 744 RVA: 0x0001C798 File Offset: 0x0001AB98
+    
     protected Thing Must
     {
       get
@@ -28,8 +23,7 @@ namespace RwWineMod
         return this.job.GetTarget(TargetIndex.B).Thing;
       }
     }
-
-    // Token: 0x060002E9 RID: 745 RVA: 0x0001C7BC File Offset: 0x0001ABBC
+    
     public override bool TryMakePreToilReservations(bool errorOnFailed)
     {
       Pawn pawn = this.pawn;
@@ -49,8 +43,7 @@ namespace RwWineMod
       }
       return result;
     }
-
-    // Token: 0x060002EA RID: 746 RVA: 0x0001C824 File Offset: 0x0001AC24
+    
     protected override IEnumerable<Toil> MakeNewToils()
     {
       this.FailOnDespawnedNullOrForbidden(TargetIndex.A);
@@ -77,14 +70,11 @@ namespace RwWineMod
       };
       yield break;
     }
-
-    // Token: 0x0400020C RID: 524
+    
     private const TargetIndex BarrelInd = TargetIndex.A;
-
-    // Token: 0x0400020D RID: 525
+    
     private const TargetIndex MustInd = TargetIndex.B;
-
-    // Token: 0x0400020E RID: 526
+    
     private const int Duration = 200;
   }
 }

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("rw-wine-mod")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("RwWineMod")]
+[assembly: AssemblyDescription("Adds winemaking to Rimworld")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("rw-wine-mod")]
+[assembly: AssemblyProduct("RwWineMod")]
 [assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Source/SymbolResolver_AddMustToFermentingBarrels.cs
+++ b/Source/SymbolResolver_AddMustToFermentingBarrels.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+using RimWorld.BaseGen;
+
+namespace RwWineMod
+{
+  public class SymbolResolver_AddMustToFermentingBarrels : SymbolResolver
+  {
+    public override void Resolve(ResolveParams rp)
+    {
+      Map map = BaseGen.globalSettings.map;
+      SymbolResolver_AddMustToFermentingBarrels.barrels.Clear();
+      CellRect.CellRectIterator iterator = rp.rect.GetIterator();
+      while (!iterator.Done())
+      {
+        List<Thing> thingList = iterator.Current.GetThingList(map);
+        for (int i = 0; i < thingList.Count; i++)
+        {
+          Building_FermentingBarrel building_FermentingBarrel = thingList[i] as Building_FermentingBarrel;
+          if (building_FermentingBarrel != null && !SymbolResolver_AddMustToFermentingBarrels.barrels.Contains(building_FermentingBarrel))
+          {
+            SymbolResolver_AddMustToFermentingBarrels.barrels.Add(building_FermentingBarrel);
+          }
+        }
+        iterator.MoveNext();
+      }
+      float progress = Rand.Range(0.1f, 0.9f);
+      for (int j = 0; j < SymbolResolver_AddMustToFermentingBarrels.barrels.Count; j++)
+      {
+        if (!SymbolResolver_AdMustToFermentingBarrels.barrels[j].Fermented)
+        {
+          int num = Rand.RangeInclusive(1, 25);
+          num = Mathf.Min(num, SymbolResolver_AddMustToFermentingBarrels.barrels[j].SpaceLeftForWort);
+          if (num > 0)
+          {
+            SymbolResolver_AddMustToFermentingBarrels.barrels[j].AddWort(num);
+            SymbolResolver_AddMustToFermentingBarrels.barrels[j].Progress = progress;
+          }
+        }
+      }
+      SymbolResolver_AddMustToFermentingBarrels.barrels.Clear();
+    }
+    
+    private static List<Building_FermentingBarrel> barrels = new List<Building_FermentingBarrel>();
+  }
+}

--- a/Source/SymbolResolver_AddMustToFermentingBarrels.cs
+++ b/Source/SymbolResolver_AddMustToFermentingBarrels.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Verse;
+using RimWorld;
 using RimWorld.BaseGen;
 
 namespace RwWineMod
@@ -29,7 +30,7 @@ namespace RwWineMod
       float progress = Rand.Range(0.1f, 0.9f);
       for (int j = 0; j < SymbolResolver_AddMustToFermentingBarrels.barrels.Count; j++)
       {
-        if (!SymbolResolver_AdMustToFermentingBarrels.barrels[j].Fermented)
+        if (!SymbolResolver_AddMustToFermentingBarrels.barrels[j].Fermented)
         {
           int num = Rand.RangeInclusive(1, 25);
           num = Mathf.Min(num, SymbolResolver_AddMustToFermentingBarrels.barrels[j].SpaceLeftForWort);

--- a/Source/WineJobDefOf.cs
+++ b/Source/WineJobDefOf.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Verse;
+using RimWorld;
+
+namespace RwWineMod
+{
+  [DefOf]
+  public static class WineJobDefOf
+  {
+    static WineJobDefOf()
+    {
+      DefOfHelper.EnsureInitializedInCtor(typeof(WineJobDefOf));
+    }
+
+    public static JobDef FillMustFermentingBarrel;
+  }
+}

--- a/Source/WineThingDefOf.cs
+++ b/Source/WineThingDefOf.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Verse;
+using RimWorld;
+
+namespace RwWineMod
+{
+  [DefOf]
+  public static class WineThingDefOf
+  {
+    static WineThingDefOf()
+    {
+      DefOfHelper.EnsureInitializedInCtor(typeof(WineThingDefOf));
+    }
+
+    public static ThingDef Must;
+  }
+}
+

--- a/Source/WorkGiver_FillMustFermentingBarrel.cs
+++ b/Source/WorkGiver_FillMustFermentingBarrel.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Verse;
+using Verse.AI;
+using RimWorld;
+
+namespace RwWineMod
+{
+  // Token: 0x02000144 RID: 324
+  public class WorkGiver_FillMustFermentingBarrel : WorkGiver_Scanner
+  {
+    // Token: 0x17000103 RID: 259
+    // (get) Token: 0x060006BC RID: 1724 RVA: 0x0003E6B4 File Offset: 0x0003CAB4
+    public override ThingRequest PotentialWorkThingRequest
+    {
+      get
+      {
+        return ThingRequest.ForDef(ThingDefOf.FermentingBarrel);
+      }
+    }
+
+    // Token: 0x17000104 RID: 260
+    // (get) Token: 0x060006BD RID: 1725 RVA: 0x0003E6C0 File Offset: 0x0003CAC0
+    public override PathEndMode PathEndMode
+    {
+      get
+      {
+        return PathEndMode.Touch;
+      }
+    }
+
+    // Token: 0x060006BE RID: 1726 RVA: 0x0003E6C3 File Offset: 0x0003CAC3
+    public static void ResetStaticData()
+    {
+      WorkGiver_FillMustFermentingBarrel.TemperatureTrans = "BadTemperature".Translate().ToLower();
+      WorkGiver_FillMustFermentingBarrel.NoMustTrans = "NoMust".Translate();
+    }
+
+    // Token: 0x060006BF RID: 1727 RVA: 0x0003E6E8 File Offset: 0x0003CAE8
+    public override bool HasJobOnThing(Pawn pawn, Thing t, bool forced = false)
+    {
+      Building_FermentingBarrel building_FermentingBarrel = t as Building_FermentingBarrel;
+      if (building_FermentingBarrel == null || building_FermentingBarrel.Fermented || building_FermentingBarrel.SpaceLeftForWort <= 0)
+      {
+        return false;
+      }
+      float ambientTemperature = building_FermentingBarrel.AmbientTemperature;
+      CompProperties_TemperatureRuinable compProperties = building_FermentingBarrel.def.GetCompProperties<CompProperties_TemperatureRuinable>();
+      if (ambientTemperature < compProperties.minSafeTemperature + 2f || ambientTemperature > compProperties.maxSafeTemperature - 2f)
+      {
+        JobFailReason.Is(WorkGiver_FillMustFermentingBarrel.TemperatureTrans, null);
+        return false;
+      }
+      if (!t.IsForbidden(pawn))
+      {
+        LocalTargetInfo target = t;
+        if (pawn.CanReserve(target, 1, -1, null, forced))
+        {
+          if (pawn.Map.designationManager.DesignationOn(t, DesignationDefOf.Deconstruct) != null)
+          {
+            return false;
+          }
+          if (this.FindMust(pawn, building_FermentingBarrel) == null)
+          {
+            JobFailReason.Is(WorkGiver_FillMustFermentingBarrel.NoMustTrans, null);
+            return false;
+          }
+          return !t.IsBurning();
+        }
+      }
+      return false;
+    }
+
+    // Token: 0x060006C0 RID: 1728 RVA: 0x0003E7D8 File Offset: 0x0003CBD8
+    public override Job JobOnThing(Pawn pawn, Thing t, bool forced = false)
+    {
+      Building_FermentingBarrel barrel = (Building_FermentingBarrel)t;
+      Thing t2 = this.FindMust(pawn, barrel);
+      return new Job(JobDefOf.FillMustFermentingBarrel, t, t2);
+    }
+    
+    private Thing FindMust(Pawn pawn, Building_FermentingBarrel barrel)
+    {
+      Predicate<Thing> predicate = (Thing x) => !x.IsForbidden(pawn) && pawn.CanReserve(x, 1, -1, null, false);
+      IntVec3 position = pawn.Position;
+      Map map = pawn.Map;
+      ThingRequest thingReq = ThingRequest.ForDef(ThingDefOf.Must);
+      PathEndMode peMode = PathEndMode.ClosestTouch;
+      TraverseParms traverseParams = TraverseParms.For(pawn, Danger.Deadly, TraverseMode.ByPawn, false);
+      Predicate<Thing> validator = predicate;
+      return GenClosest.ClosestThingReachable(position, map, thingReq, peMode, traverseParams, 9999f, validator, null, 0, -1, false, RegionType.Set_Passable, false);
+    }
+    
+    private static string TemperatureTrans;
+    
+    private static string NoMustTrans;
+  }
+}

--- a/Source/WorkGiver_FillMustFermentingBarrel.cs
+++ b/Source/WorkGiver_FillMustFermentingBarrel.cs
@@ -75,7 +75,7 @@ namespace RwWineMod
     {
       Building_FermentingBarrel barrel = (Building_FermentingBarrel)t;
       Thing t2 = this.FindMust(pawn, barrel);
-      return new Job(JobDefOf.FillMustFermentingBarrel, t, t2);
+      return new Job(WineJobDefOf.FillMustFermentingBarrel, t, t2);
     }
     
     private Thing FindMust(Pawn pawn, Building_FermentingBarrel barrel)
@@ -83,7 +83,7 @@ namespace RwWineMod
       Predicate<Thing> predicate = (Thing x) => !x.IsForbidden(pawn) && pawn.CanReserve(x, 1, -1, null, false);
       IntVec3 position = pawn.Position;
       Map map = pawn.Map;
-      ThingRequest thingReq = ThingRequest.ForDef(ThingDefOf.Must);
+      ThingRequest thingReq = ThingRequest.ForDef(WineThingDefOf.Must);
       PathEndMode peMode = PathEndMode.ClosestTouch;
       TraverseParms traverseParams = TraverseParms.For(pawn, Danger.Deadly, TraverseMode.ByPawn, false);
       Predicate<Thing> validator = predicate;

--- a/Source/rw-wine-mod.csproj
+++ b/Source/rw-wine-mod.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>rw-wine-mod</RootNamespace>
-    <AssemblyName>rw-wine-mod</AssemblyName>
+    <RootNamespace>RwWineMod</RootNamespace>
+    <AssemblyName>RwWineMod</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\rw-install\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -43,7 +43,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\rw-install\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <None Include="..\About\About-Debug.xml">

--- a/Source/rw-wine-mod.csproj
+++ b/Source/rw-wine-mod.csproj
@@ -56,7 +56,12 @@
     <None Include="..\Patches\**" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="WineJobDefOf.cs" />
+    <Compile Include="WineThingDefOf.cs" />
+    <Compile Include="JobDriver_FillMustFermentingBarrel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SymbolResolver_AddMustToFermentingBarrels.cs" />
+    <Compile Include="WorkGiver_FillMustFermentingBarrel.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/rw-wine-mod.sln
+++ b/rw-wine-mod.sln
@@ -15,8 +15,6 @@ Global
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DE5B7748-333A-428F-BCA9-4DB67FB289A3}.Debug|Any CPU.ActiveCfg = Release|x86
-		{DE5B7748-333A-428F-BCA9-4DB67FB289A3}.Release|Any CPU.ActiveCfg = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is a bit WIP, because it does not modify the barrels at all, and simply calls "AddWort()" on them, so they still think they have Wort and produce beer.

Still the pawns will automatically haul the Must into the Barrels, so we can modify the Barrels next.

Most of the class files were copied from decompiled versions of the Haul Wort jobs. With only small modifications.